### PR TITLE
Load db segments when opening integrated builder

### DIFF
--- a/src/components/integrated_builder.py
+++ b/src/components/integrated_builder.py
@@ -1,10 +1,16 @@
 import streamlit as st
 import streamlit.components.v1 as components
 import json
+from src.database.queries import load_saved_segments
 
 def render_integrated_builder(config, segment_definition):
     """Render an integrated drag and drop builder with sidebar and segment area"""
-    
+    if 'db_segments' not in st.session_state:
+        try:
+            st.session_state.db_segments = load_saved_segments()
+        except Exception:
+            st.session_state.db_segments = []
+
     # Convert config to JSON for JavaScript
     dimensions = []
     for cat in config.get('dimensions', []):
@@ -29,6 +35,9 @@ def render_integrated_builder(config, segment_definition):
             })
     
     segments = config.get('segments', [])
+
+    if st.session_state.get('db_segments'):
+        segments.extend(st.session_state.db_segments)
     
     # Current segment definition
     current_segment = json.dumps(segment_definition)


### PR DESCRIPTION
## Summary
- initialize `db_segments` with `load_saved_segments` in the integrated builder
- append loaded segments to the sidebar listing

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68514e63ea6c83318fbf5000d06c51f9