### PR TITLE
Fix config metrics to match database

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -71,8 +71,8 @@ dimensions:
 metrics:
   - category: "Engagement"
     items:
-      - name: "Page Views"
-        field: "page_views"
+      - name: "Pages Viewed"
+        field: "pages_viewed"
         type: "number"
         aggregation: "sum"
       - name: "Time on Page"
@@ -80,11 +80,10 @@ metrics:
         type: "number"
         aggregation: "avg"
         unit: "seconds"
-      - name: "Bounce Rate"
-        field: "bounce_rate"
+      - name: "Bounces"
+        field: "bounce"
         type: "number"
-        aggregation: "avg"
-        unit: "%"
+        aggregation: "sum"
 
   - category: "Commerce"
     items:
@@ -93,8 +92,8 @@ metrics:
         type: "number"
         aggregation: "sum"
         unit: "$"
-      - name: "Orders"
-        field: "orders"
+      - name: "Total Orders"
+        field: "total_orders"
         type: "number"
         aggregation: "sum"
       - name: "Products Viewed"
@@ -114,7 +113,7 @@ segments:
     description: "All mobile device traffic"
     container_type: "hit"
   - name: "Engaged Sessions"
-    description: "Sessions with 5+ page views"
+    description: "Sessions with 5+ pages viewed"
     container_type: "visit"
 
 operators:

--- a/src/components/drag_drop.py
+++ b/src/components/drag_drop.py
@@ -217,8 +217,8 @@ def render_drag_drop_builder():
                     <div class="draggable-item metric-item" draggable="true" data-type="metric" data-field="revenue" data-name="Revenue">
                         <span>💰</span> Revenue
                     </div>
-                    <div class="draggable-item metric-item" draggable="true" data-type="metric" data-field="page_views" data-name="Page Views">
-                        <span>👁️</span> Page Views
+                    <div class="draggable-item metric-item" draggable="true" data-type="metric" data-field="pages_viewed" data-name="Pages Viewed">
+                        <span>👁️</span> Pages Viewed
                     </div>
                     <div class="draggable-item metric-item" draggable="true" data-type="metric" data-field="time_on_page" data-name="Time on Page">
                         <span>⏱️</span> Time on Page

--- a/src/components/react_segment_builder.py
+++ b/src/components/react_segment_builder.py
@@ -77,7 +77,7 @@ def render_react_segment_builder(config, segment_definition):
         },
         'Engaged Sessions': {
             'name': 'Engaged Sessions',
-            'description': 'Sessions with 5+ page views',
+        'description': 'Sessions with 5+ pages viewed',
             'container_type': 'visit',
             'containers': [{
                 'id': 'container_eng_1',
@@ -85,8 +85,8 @@ def render_react_segment_builder(config, segment_definition):
                 'include': True,
                 'conditions': [{
                     'id': 'cond_pv_1',
-                    'field': 'page_views',
-                    'name': 'Page Views',
+                    'field': 'pages_viewed',
+                    'name': 'Pages Viewed',
                     'type': 'metric',
                     'operator': 'is greater than or equal to',
                     'value': 5,

--- a/src/components/sidebar.py
+++ b/src/components/sidebar.py
@@ -322,7 +322,7 @@ def render_sidebar(config):
         },
         'Engaged Sessions': {
             'name': 'Engaged Sessions',
-            'description': 'Sessions with 5+ page views',
+            'description': 'Sessions with 5+ pages viewed',
             'container_type': 'visit',
             'containers': [{
                 'id': 'container_engaged_1',
@@ -330,8 +330,8 @@ def render_sidebar(config):
                 'include': True,
                 'conditions': [{
                     'id': 'cond_pageviews_1',
-                    'field': 'page_views',  # Fixed field mapping
-                    'name': 'Page Views',
+                    'field': 'pages_viewed',
+                    'name': 'Pages Viewed',
                     'type': 'metric',
                     'category': 'Engagement',
                     'operator': 'is greater than or equal to',


### PR DESCRIPTION
## Summary
- align metrics with columns in the `hits`, `sessions`, and `users` tables
- update sample segments to use the new fields

## Testing
- `python verify_system.py` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68517a7585d48331ab94bfa5f61690a1