### PR TITLE
Fix session/user joins

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -16,12 +16,15 @@ dimensions:
     items:
       - name: "Page URL"
         field: "page_url"
+        table: "hits"
         type: "string"
       - name: "Page Title"
         field: "page_title"
+        table: "hits"
         type: "string"
       - name: "Page Type"
         field: "page_type"
+        table: "hits"
         type: "string"
         values: ["Home", "Product", "Category", "Checkout", "Search"]
 
@@ -29,13 +32,16 @@ dimensions:
     items:
       - name: "Browser Name"
         field: "browser_name"
+        table: "hits"
         type: "string"
         values: ["Chrome", "Firefox", "Safari", "Edge", "Other"]
       - name: "Browser Version"
         field: "browser_version"
+        table: "hits"
         type: "string"
       - name: "Device Type"
         field: "device_type"
+        table: "hits"
         type: "string"
         values: ["Desktop", "Mobile", "Tablet"]
 
@@ -43,29 +49,36 @@ dimensions:
     items:
       - name: "User ID"
         field: "user_id"
+        table: "hits"
         type: "string"
       - name: "User Type"
         field: "user_type"
+        table: "users"
         type: "string"
         values: ["New", "Returning", "Registered"]
       - name: "Country"
         field: "country"
+        table: "hits"
         type: "string"
       - name: "City"
         field: "city"
+        table: "hits"
         type: "string"
 
   - category: "Traffic"
     items:
       - name: "Campaign"
         field: "campaign"
+        table: "hits"
         type: "string"
       - name: "Source"
         field: "traffic_source"
+        table: "hits"
         type: "string"
         values: ["Direct", "Organic", "Paid", "Social", "Email", "Referral"]
       - name: "Medium"
         field: "traffic_medium"
+        table: "hits"
         type: "string"
 
 metrics:
@@ -73,15 +86,18 @@ metrics:
     items:
       - name: "Page Views"
         field: "page_views"
+        table: "sessions"
         type: "number"
         aggregation: "sum"
       - name: "Time on Page"
         field: "time_on_page"
+        table: "hits"
         type: "number"
         aggregation: "avg"
         unit: "seconds"
       - name: "Bounce Rate"
         field: "bounce_rate"
+        table: "hits"
         type: "number"
         aggregation: "avg"
         unit: "%"
@@ -90,19 +106,23 @@ metrics:
     items:
       - name: "Revenue"
         field: "revenue"
+        table: "hits"
         type: "number"
         aggregation: "sum"
         unit: "$"
       - name: "Orders"
         field: "orders"
+        table: "users"
         type: "number"
         aggregation: "sum"
       - name: "Products Viewed"
         field: "products_viewed"
+        table: "hits"
         type: "number"
         aggregation: "sum"
       - name: "Cart Additions"
         field: "cart_additions"
+        table: "hits"
         type: "number"
         aggregation: "sum"
 

--- a/src/components/library.py
+++ b/src/components/library.py
@@ -545,7 +545,7 @@ def get_saved_segments():
                     'include': True,
                     'conditions': [{
                         'id': 'cond_pv_1',
-                        'field': 'total_hits',
+                        'field': 'page_views',
                         'name': 'Page Views',
                         'type': 'metric',
                         'category': 'Engagement',

--- a/src/utils/query_builder.py
+++ b/src/utils/query_builder.py
@@ -1,5 +1,32 @@
 import streamlit as st
 import json
+import yaml
+from pathlib import Path
+
+CONFIG_PATH = Path(__file__).resolve().parents[2] / "config.yaml"
+try:
+    with open(CONFIG_PATH, "r") as f:
+        _CONFIG = yaml.safe_load(f)
+except Exception:
+    _CONFIG = {}
+
+
+def _build_field_table_map(cfg):
+    mapping = {}
+    for section in ["dimensions", "metrics"]:
+        for cat in cfg.get(section, []):
+            for item in cat.get("items", []):
+                mapping[item.get("field")] = item.get("table", "hits")
+    return mapping
+
+
+FIELD_TABLE_MAP = _build_field_table_map(_CONFIG)
+FIELD_TABLE_MAP.setdefault("total_hits", "sessions")
+FIELD_TABLE_MAP.setdefault("total_revenue", "sessions")
+FIELD_TABLE_MAP.setdefault("session_duration", "sessions")
+FIELD_TABLE_MAP.setdefault("pages_viewed", "sessions")
+FIELD_TABLE_MAP.setdefault("total_orders", "users")
+FIELD_TABLE_MAP.setdefault("total_sessions", "users")
 
 def build_sql_from_segment(segment_definition):
     """Build SQL query from segment definition - FIXED VERSION"""
@@ -14,11 +41,13 @@ def build_sql_from_segment(segment_definition):
     
     # Build container queries
     container_queries = []
+    required_joins = set()
     
     for container in containers:
-        container_sql = build_container_sql(container, container_type)
+        container_sql, joins = build_container_sql(container, container_type)
         if container_sql:
             container_queries.append(container_sql)
+            required_joins.update(joins)
     
     if not container_queries:
         return "SELECT * FROM hits LIMIT 0"
@@ -31,9 +60,15 @@ def build_sql_from_segment(segment_definition):
         final_query = f"({f') {segment_logic} ('.join(container_queries)})"
     
     # Wrap in main query
+    join_clauses = ""
+    if "sessions" in required_joins:
+        join_clauses += " LEFT JOIN sessions s ON h.session_id = s.session_id"
+    if "users" in required_joins:
+        join_clauses += " LEFT JOIN users u ON h.user_id = u.user_id"
+
     main_query = f"""
     SELECT DISTINCT h.*
-    FROM hits h
+    FROM hits h{join_clauses}
     WHERE {final_query}
     ORDER BY h.timestamp DESC
     """
@@ -45,7 +80,7 @@ def build_container_sql(container, main_container_type):
     
     conditions = container.get('conditions', [])
     if not conditions:
-        return None
+        return None, set()
     
     container_type = container.get('type', main_container_type)
     include = container.get('include', True)
@@ -53,16 +88,21 @@ def build_container_sql(container, main_container_type):
     
     # Build condition SQL
     condition_sqls = []
-    
-    alias = 'h' if container_type == 'hit' else None
+    used_tables = set()
+
+    if container_type == 'hit':
+        aliases = {"hits": "h", "sessions": "s", "users": "u"}
+    else:
+        aliases = {"hits": "h2", "sessions": "s2", "users": "u2"}
 
     for condition in conditions:
-        condition_sql = build_condition_sql(condition, alias=alias)
+        condition_sql, table = build_condition_sql(condition, aliases)
         if condition_sql:
             condition_sqls.append(condition_sql)
+            used_tables.add(table)
     
     if not condition_sqls:
-        return None
+        return None, set()
     
     # Combine conditions
     if len(condition_sqls) == 1:
@@ -74,63 +114,72 @@ def build_container_sql(container, main_container_type):
     if container_type == 'hit':
         # Hit level - direct conditions
         base_query = combined_conditions
+        join_tables = used_tables - {"hits"}
     elif container_type == 'visit':
         # Visit level - exists in session
+        joins = ""
+        if "sessions" in used_tables:
+            joins += " LEFT JOIN sessions s2 ON h2.session_id = s2.session_id"
+        if "users" in used_tables:
+            joins += " LEFT JOIN users u2 ON h2.user_id = u2.user_id"
         base_query = f"""
         h.session_id IN (
-            SELECT DISTINCT session_id 
-            FROM hits 
+            SELECT DISTINCT h2.session_id
+            FROM hits h2{joins}
             WHERE {combined_conditions}
         )
         """
+        join_tables = set()
     elif container_type == 'visitor':
         # Visitor level - exists for user
+        joins = ""
+        if "sessions" in used_tables:
+            joins += " LEFT JOIN sessions s2 ON h2.session_id = s2.session_id"
+        if "users" in used_tables:
+            joins += " LEFT JOIN users u2 ON h2.user_id = u2.user_id"
         base_query = f"""
         h.user_id IN (
-            SELECT DISTINCT user_id 
-            FROM hits 
+            SELECT DISTINCT h2.user_id
+            FROM hits h2{joins}
             WHERE {combined_conditions}
         )
         """
+        join_tables = set()
     else:
         base_query = combined_conditions
+        join_tables = used_tables - {"hits"}
     
     # Handle include/exclude
     if not include:
         base_query = f"NOT ({base_query})"
-    
-    return base_query
 
-def build_condition_sql(condition, alias=None):
-    """Build SQL for a single condition - ENHANCED VERSION
+    return base_query, join_tables
 
-    Parameters
-    ----------
-    condition : dict
-        Condition definition.
-    alias : str or None
-        Optional table alias to prefix field references with.
-    """
-    
+def build_condition_sql(condition, aliases):
+    """Build SQL for a single condition and return used table."""
+
     field = condition.get('field')
     operator = condition.get('operator', 'equals')
     value = condition.get('value')
     data_type = condition.get('data_type', 'string')
     
     if not field:
-        return None
+        return None, 'hits'
+
+    table = FIELD_TABLE_MAP.get(field, 'hits')
+    alias = aliases.get(table, '')
     
     # Handle exists/does not exist operators
     field_ref = f"{alias}.{field}" if alias else field
 
     if operator == 'exists':
-        return f"{field_ref} IS NOT NULL"
+        return f"{field_ref} IS NOT NULL", table
     elif operator == 'does not exist':
-        return f"{field_ref} IS NULL"
+        return f"{field_ref} IS NULL", table
     
     # For other operators, value is required
     if value is None or str(value).strip() == '':
-        return None
+        return None, table
     
     # Clean and format value
     clean_value = str(value).strip()
@@ -140,7 +189,7 @@ def build_condition_sql(condition, alias=None):
         try:
             numeric_value = float(clean_value)
             if operator == 'equals':
-                return f"{field_ref} = {numeric_value}"
+                return f"{field_ref} = {numeric_value}", table
             elif operator == 'does not equal':
                 return f"{field_ref} != {numeric_value}"
             elif operator == 'is greater than':
@@ -152,13 +201,12 @@ def build_condition_sql(condition, alias=None):
             elif operator == 'is less than or equal to':
                 return f"{field_ref} <= {numeric_value}"
             elif operator == 'is between':
-                # Handle between operator
                 value2 = condition.get('value2')
                 if value2 is not None:
                     numeric_value2 = float(value2)
-                    return f"{field_ref} BETWEEN {numeric_value} AND {numeric_value2}"
+                    return f"{field_ref} BETWEEN {numeric_value} AND {numeric_value2}", table
                 else:
-                    return f"{field_ref} = {numeric_value}"
+                    return f"{field_ref} = {numeric_value}", table
         except (ValueError, TypeError):
             # If not a valid number, treat as string
             data_type = 'string'
@@ -169,22 +217,22 @@ def build_condition_sql(condition, alias=None):
         escaped_value = clean_value.replace("'", "''")
 
         if operator == 'equals':
-            return f"{field_ref} = '{escaped_value}'"
+            return f"{field_ref} = '{escaped_value}'", table
         elif operator == 'does not equal':
-            return f"{field_ref} != '{escaped_value}'"
+            return f"{field_ref} != '{escaped_value}'", table
         elif operator == 'contains':
-            return f"{field_ref} LIKE '%{escaped_value}%'"
+            return f"{field_ref} LIKE '%{escaped_value}%'", table
         elif operator == 'does not contain':
-            return f"{field_ref} NOT LIKE '%{escaped_value}%'"
+            return f"{field_ref} NOT LIKE '%{escaped_value}%'", table
         elif operator == 'starts with':
-            return f"{field_ref} LIKE '{escaped_value}%'"
+            return f"{field_ref} LIKE '{escaped_value}%'", table
         elif operator == 'ends with':
-            return f"{field_ref} LIKE '%{escaped_value}'"
+            return f"{field_ref} LIKE '%{escaped_value}'", table
         else:
             # Default to equals for unknown operators
-            return f"{field_ref} = '{escaped_value}'"
+            return f"{field_ref} = '{escaped_value}'", table
     
-    return None
+    return None, table
 
 def render_query_builder(config):
     """Render a simple query builder interface"""


### PR DESCRIPTION
## Summary
- track which table each field belongs to with a new `table` key in config
- update query builder to join against `sessions` and `users` when needed
- fix library example to use `page_views`

## Testing
- `python3 verify_system.py > /tmp/verify.log && tail -n 20 /tmp/verify.log`
- `python3 -m py_compile src/utils/query_builder.py`

------
https://chatgpt.com/codex/tasks/task_e_68517a6f5e708331be2a8de92083b664