### PR TITLE
Fix preview recalculation after segment changes

### DIFF
--- a/src/components/library.py
+++ b/src/components/library.py
@@ -656,6 +656,7 @@ def load_segment_to_builder(segment):
         # Reset preview selector and clear preview data
         st.session_state.preview_segment_selector = "Current Segment"
         st.session_state.preview_data = None
+        st.session_state.last_preview_segment = None
         
         # Switch to builder tab
         st.session_state.active_tab = 0
@@ -685,7 +686,8 @@ def load_segment_and_preview(segment):
         # Reset preview selector and clear preview data
         st.session_state.preview_segment_selector = "Current Segment"
         st.session_state.preview_data = None
-        
+        st.session_state.last_preview_segment = None
+
         # Switch to preview tab
         st.session_state.active_tab = 1
         

--- a/src/components/react_segment_builder.py
+++ b/src/components/react_segment_builder.py
@@ -1064,6 +1064,7 @@ def render_react_segment_builder(config, segment_definition):
                 segment_data = json.loads(match.group(1))
                 st.session_state.segment_definition = segment_data
                 st.session_state.preview_data = None  # Clear preview to force regeneration
+                st.session_state.last_preview_segment = None
         except:
             pass
     

--- a/src/components/segment_builder.py
+++ b/src/components/segment_builder.py
@@ -828,6 +828,8 @@ def validate_and_save_segment():
             # Add success flag to session state
             st.session_state.segment_saved = True
             st.session_state.last_saved_segment = segment_def.get('name')
+            st.session_state.preview_data = None
+            st.session_state.last_preview_segment = None
 
             # Refresh sidebar segment list from the database
             try:

--- a/src/components/sidebar.py
+++ b/src/components/sidebar.py
@@ -544,6 +544,7 @@ def add_to_segment(item, item_type, category):
     st.success(f"✅ Added {item['name']} to segment")
     # Clear preview to force regeneration
     st.session_state.preview_data = None
+    st.session_state.last_preview_segment = None
     # Trigger segment update
     st.session_state.segment_updated = True
     # Force a rerun to update the UI
@@ -573,6 +574,7 @@ def add_segment_to_builder(segment):
         # Reset preview selector and clear cached data
         st.session_state.preview_segment_selector = "Current Segment"
         st.session_state.preview_data = None
+        st.session_state.last_preview_segment = None
         st.success(f"✅ Loaded segment: {segment['name']}")
         # Force rerun
         st.rerun()


### PR DESCRIPTION
## Summary
- ensure library segment loaders clear preview cache and last segment
- reset preview cache when picking a segment from the sidebar
- reset cached preview after saving a segment
- keep React builder consistent

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python verify_system.py` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6851b36d10e48331aa9105a87b004342